### PR TITLE
Remove buble from rollup

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 import commonjs from 'rollup-plugin-commonjs';
 import resolve from 'rollup-plugin-node-resolve';
-import buble from 'rollup-plugin-buble';
+
 const pkg = require('./package.json');
 
 export default {
@@ -12,7 +12,6 @@ export default {
   external: ['fs', 'path', 'crypto', 'clean-css'],
   plugins: [
     resolve(),
-    commonjs(),
-    buble()
+    commonjs()
   ]
 };


### PR DESCRIPTION
Seems, Buble is not an actual dependency. Besides, it's not useful for rollup plugins.