### PR TITLE
Support of Rollup 2.x.x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,12 +33,13 @@ export default (opt = {}) => {
 	return {
 		name: 'html',
 		writeBundle(config, data) {
+                        const bundle = data || config;
 			const isHTML = /^.*<html>.*<\/html>$/.test(template);
 			const $ = cheerio.load(isHTML?template:readFileSync(template).toString());
 			const head = $('head');
 			const body = $('body');
 			let entryConfig = {};
-			Object.values(config).forEach((c) => {
+			Object.values(bundle).forEach((c) => {
 				if (c.isEntry) entryConfig = c
 			})
 			const { fileName,	sourcemap } = entryConfig


### PR DESCRIPTION
Seems, there's an official way to check which signature of `writeBundle` used in current Rollup's version. Check this comment:

```
So you can detect the signature of the hook by checking if the second parameter is used; in that case, it is the bundle, otherwise the first is the bundle.
```
https://github.com/rollup/rollup/pull/3361#issue-368732071